### PR TITLE
set android.hardware.microphone feature as optional

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,11 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- The android.hardware.microphone feature requirement is implied by the RECORD_AUDIO permission but isn't available on every Android TV devices. -->
+    <uses-feature
+        android:name="android.hardware.microphone"
+        android:required="false" />
+
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />


### PR DESCRIPTION
Use of android.permission.RECORD_AUDIO, needed for the SearchActivity, implies a requirement on the android.hardware.microphone feature.
However the android.hardware.microphone isn't part of the Android TV platform, hence having this requirement may prevent the distribution of the application to Android TV devices through the Play Store.

The voice recognition system on the platform is using the microphone from the remote but this mic isn't directly accessible as a standard one.