### PR TITLE
Handle power down on Sony Bravia correctly and use MediaSession for PlaybackOverlayFragment updates

### DIFF
--- a/app/src/main/java/com/example/android/tvleanback/Utils.java
+++ b/app/src/main/java/com/example/android/tvleanback/Utils.java
@@ -18,9 +18,13 @@ package com.example.android.tvleanback;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.media.MediaMetadataRetriever;
+import android.os.Build;
 import android.view.Display;
 import android.view.WindowManager;
 import android.widget.Toast;
+
+import java.util.HashMap;
 
 /**
  * A collection of utility methods, all static.
@@ -63,5 +67,16 @@ public class Utils {
     public static int convertDpToPixel(Context ctx, int dp) {
         float density = ctx.getResources().getDisplayMetrics().density;
         return Math.round((float) dp * density);
+    }
+
+
+    public static long getDuration(String videoUrl) {
+        MediaMetadataRetriever mmr = new MediaMetadataRetriever();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            mmr.setDataSource(videoUrl, new HashMap<String, String>());
+        } else {
+            mmr.setDataSource(videoUrl);
+        }
+        return Long.parseLong(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
     }
 }

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -65,6 +65,8 @@ public class PlaybackActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        createMediaSession();
+
         setContentView(R.layout.playback_controls);
         loadViews();
         //Example for handling resizing view for overscan
@@ -74,7 +76,6 @@ public class PlaybackActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        createMediaSession();
     }
 
     @Override

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -99,7 +99,7 @@ public class PlaybackActivity extends Activity {
         }
     }
 
-    private void playPause(Boolean doPlay) {
+    private void playPause(boolean doPlay) {
         if (mPlaybackState == LeanbackPlaybackState.IDLE) {
             setupCallbacks();
         }
@@ -260,7 +260,6 @@ public class PlaybackActivity extends Activity {
         super.onStop();
         Log.d(TAG, "pausing playback in onStop");
         pausePlayback();
-
     }
 
 
@@ -327,6 +326,7 @@ public class PlaybackActivity extends Activity {
         @Override
         public void onFastForward() {
             if (mDuration != -1) {
+                // Fast forward 10 seconds.
                 int newPosition = mVideoView.getCurrentPosition() + (10 * 1000);
                 if (newPosition > mDuration) {
                     newPosition = (int) mDuration;
@@ -339,6 +339,7 @@ public class PlaybackActivity extends Activity {
         @Override
         public void onRewind() {
             Log.d(TAG, "received fastForward in MediaSession.Callback");
+            // rewind 10 seconds
             int newPosition = mVideoView.getCurrentPosition() - (10 * 1000);
             if (newPosition < 0) {
                 newPosition = 0;

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -140,8 +140,11 @@ public class PlaybackActivity extends Activity {
 
         String title = movie.getTitle().replace("_", " -");
 
+        metadataBuilder.putString(MediaMetadata.METADATA_KEY_MEDIA_ID, movie.getId());
         metadataBuilder.putString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE, title);
         metadataBuilder.putString(MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE,
+                movie.getStudio());
+        metadataBuilder.putString(MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION,
                 movie.getDescription());
         metadataBuilder.putString(MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI,
                 movie.getCardImageUrl());
@@ -331,6 +334,7 @@ public class PlaybackActivity extends Activity {
 
             mVideoView.setVideoPath(movie.getVideoUrl());
             mPlaybackState = LeanbackPlaybackState.PAUSED;
+            updateMetadata(movie);
             playPause(isPlaying);
         }
 

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -18,6 +18,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.media.MediaMetadata;
 import android.media.MediaPlayer;
+import android.media.session.MediaController;
 import android.media.session.MediaSession;
 import android.media.session.PlaybackState;
 import android.net.Uri;
@@ -57,10 +58,6 @@ public class PlaybackActivity extends Activity implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.playback_controls);
-        loadViews();
-        //Example for handling resizing view for overscan
-        //overScan();
 
         mSession = new MediaSession (this, "LeanbackSampleApp");
         mSession.setCallback(new MediaSessionCallback());
@@ -69,6 +66,12 @@ public class PlaybackActivity extends Activity implements
 
         mSession.setActive(true);
 
+        setMediaController(new MediaController(this, mSession.getSessionToken()));
+
+        setContentView(R.layout.playback_controls);
+        loadViews();
+        //Example for handling resizing view for overscan
+        //overScan();
     }
 
     @Override
@@ -81,6 +84,10 @@ public class PlaybackActivity extends Activity implements
      * Implementation of OnPlayPauseClickedListener
      */
     public void onFragmentPlayPause(Movie movie, int position, Boolean playPause) {
+        play(movie, position, playPause);
+    }
+
+    private void play(Movie movie, int position, Boolean playPause) {
         mVideoView.setVideoPath(movie.getVideoUrl());
 
         if (position == 0 || mPlaybackState == LeanbackPlaybackState.IDLE) {

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -25,7 +25,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.widget.FrameLayout;
 import android.widget.VideoView;
 
@@ -277,28 +276,6 @@ public class PlaybackActivity extends Activity {
     private void stopPlayback() {
         if (mVideoView != null) {
             mVideoView.stopPlayback();
-        }
-    }
-
-    @Override
-     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        PlaybackOverlayFragment playbackOverlayFragment = (PlaybackOverlayFragment) getFragmentManager().findFragmentById(R.id.playback_controls_fragment);
-        switch (keyCode) {
-            case KeyEvent.KEYCODE_MEDIA_PLAY:
-                playbackOverlayFragment.togglePlayback(false);
-                return true;
-            case KeyEvent.KEYCODE_MEDIA_PAUSE:
-                playbackOverlayFragment.togglePlayback(false);
-                return true;
-            case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                if (mPlaybackState == LeanbackPlaybackState.PLAYING) {
-                    playbackOverlayFragment.togglePlayback(false);
-                } else {
-                    playbackOverlayFragment.togglePlayback(true);
-                }
-                return true;
-            default:
-                return super.onKeyUp(keyCode, event);
         }
     }
 

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -51,6 +51,7 @@ public class PlaybackActivity extends Activity {
     private static final double MEDIA_RIGHT_MARGIN = 0.025;
     private static final double MEDIA_BOTTOM_MARGIN = 0.025;
     private static final double MEDIA_LEFT_MARGIN = 0.025;
+    public static final String AUTO_PLAY = "auto_play";
     private VideoView mVideoView;
     private LeanbackPlaybackState mPlaybackState = LeanbackPlaybackState.IDLE;
     private MediaSession mSession;
@@ -117,7 +118,7 @@ public class PlaybackActivity extends Activity {
         PlaybackState.Builder stateBuilder = new PlaybackState.Builder()
                 .setActions(getAvailableActions());
         int state = PlaybackState.STATE_PLAYING;
-        if (mPlaybackState == LeanbackPlaybackState.PAUSED) {
+        if (mPlaybackState == LeanbackPlaybackState.PAUSED || mPlaybackState == LeanbackPlaybackState.IDLE) {
             state = PlaybackState.STATE_PAUSED;
         }
         stateBuilder.setState(state, mVideoView.getCurrentPosition(), 1.0f);
@@ -307,15 +308,13 @@ public class PlaybackActivity extends Activity {
 
         @Override
         public void onPlayFromMediaId(String mediaId, Bundle extras) {
-            // must be called before setting the new video path on mVideoView
-            boolean isPlaying = mVideoView.isPlaying();
-
             Movie movie = getMovieById(mediaId);
 
             setVideoPath(movie.getVideoUrl());
+
             mPlaybackState = LeanbackPlaybackState.PAUSED;
             updateMetadata(movie);
-            playPause(isPlaying);
+            playPause(extras.getBoolean(AUTO_PLAY));
         }
 
         @Override

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
@@ -111,7 +111,7 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
     private int mClickCount;
 
     private MediaController mMediaController;
-    private android.media.session.MediaController.Callback mMediaControllerCallback = new MediaControllerCallback();
+    private MediaController.Callback mMediaControllerCallback = new MediaControllerCallback();
     private int mCurrentPlaybackState;
 
     @Override

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
@@ -13,6 +13,7 @@
  */
 package com.example.android.tvleanback.ui;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.media.MediaMetadata;
@@ -159,26 +160,35 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
         setOnItemViewClickedListener(new ItemViewClickedListener());
     }
 
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        mMediaController = getActivity().getMediaController();
+        Log.d(TAG, "register callback of mediaController");
+        mMediaController.registerCallback(mMediaControllerCallback);
+    }
 
     @Override
     public void onStart() {
         super.onStart();
-
-        mMediaController = getActivity().getMediaController();
-        Log.d(TAG, "register callback of mediaController");
-        mMediaController.registerCallback(mMediaControllerCallback);
     }
 
 
     @Override
     public void onStop() {
         stopProgressAutomation();
+        super.onStop();
+    }
+
+    @Override
+    public void onDetach() {
         if (mMediaController != null) {
             Log.d(TAG, "unregister callback of mediaController");
             mMediaController.unregisterCallback(mMediaControllerCallback);
         }
-        super.onStop();
+        super.onDetach();
     }
+
 
     @Override
     public void onResume() {

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
@@ -15,6 +15,7 @@ package com.example.android.tvleanback.ui;
 
 import android.content.Context;
 import android.content.Intent;
+import android.media.MediaMetadata;
 import android.media.MediaMetadataRetriever;
 import android.media.session.MediaController;
 import android.media.session.PlaybackState;
@@ -312,18 +313,22 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
     }
 
     private void updatePlaybackRow(int index) {
-        if (mPlaybackControlsRow.getItem() != null) {
-            Movie item = (Movie) mPlaybackControlsRow.getItem();
-            item.setTitle(mItems.get(mCurrentItem).getTitle());
-            item.setStudio(mItems.get(mCurrentItem).getStudio());
-        }
-        if (SHOW_IMAGE) {
-            updateVideoImage(mItems.get(mCurrentItem).getCardImageUrl());
-        }
+        updateMovieView(mItems.get(mCurrentItem).getTitle(), mItems.get(mCurrentItem).getStudio(), mItems.get(mCurrentItem).getCardImageUrl());
         mRowsAdapter.notifyArrayItemRangeChanged(0, 1);
         mPlaybackControlsRow.setTotalTime(getDuration());
         mPlaybackControlsRow.setCurrentTime(0);
         mPlaybackControlsRow.setBufferedProgress(0);
+    }
+
+    private void updateMovieView(String title, String studio, String cardImageUrl) {
+        if (mPlaybackControlsRow.getItem() != null) {
+            Movie item = (Movie) mPlaybackControlsRow.getItem();
+            item.setTitle(title);
+            item.setStudio(studio);
+        }
+        if (SHOW_IMAGE) {
+            updateVideoImage(cardImageUrl);
+        }
     }
 
     private void addOtherRows() {
@@ -372,7 +377,6 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
         }
         mMediaController.getTransportControls().playFromMediaId(mItems.get(mCurrentItem).getId(), null);
         mFfwRwdSpeed = INITIAL_SPEED;
-        updatePlaybackRow(mCurrentItem);
     }
 
     private void prev() {
@@ -381,7 +385,6 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
         }
         mMediaController.getTransportControls().playFromMediaId(mItems.get(mCurrentItem).getId(), null);
         mFfwRwdSpeed = INITIAL_SPEED;
-        updatePlaybackRow(mCurrentItem);
     }
 
     private void fastForward() {
@@ -504,6 +507,16 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
             int currentTime = (int)state.getPosition();
             mPlaybackControlsRow.setCurrentTime(currentTime);
             mPlaybackControlsRow.setBufferedProgress(currentTime + SIMULATED_BUFFERED_TIME);
+        }
+
+        @Override
+        public void onMetadataChanged(MediaMetadata metadata) {
+            Log.d(TAG, "received update of media metadata");
+            updateMovieView(
+                metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE),
+                metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE),
+                metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI)
+            );
         }
     }
 }


### PR DESCRIPTION
This change makes sure the playback is paused when the TV (Sony Bravia) is switched of. In this case playback is paused in the background and the UI of the PlaybackOverlayFragment synched with the playback state.

Further the PlaybackOverlayFragment now uses the MediaSession to sync the UI with the playback state which is handled in the PlaybackActivity. Communication between the fragment and the activity is now completely based on MediaSession and MediaController with their callbacks.