### PR TITLE
Refactoring to keep playback position after visibleBehind

### DIFF
--- a/app/src/main/java/com/example/android/tvleanback/Utils.java
+++ b/app/src/main/java/com/example/android/tvleanback/Utils.java
@@ -16,13 +16,17 @@
 
 package com.example.android.tvleanback;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Point;
 import android.media.MediaMetadataRetriever;
 import android.os.Build;
+import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
+import android.widget.FrameLayout;
 import android.widget.Toast;
+import android.widget.VideoView;
 
 import java.util.HashMap;
 
@@ -30,6 +34,15 @@ import java.util.HashMap;
  * A collection of utility methods, all static.
  */
 public class Utils {
+
+    public interface MediaDimensions {
+        double MEDIA_HEIGHT = 0.95;
+        double MEDIA_WIDTH = 0.95;
+        double MEDIA_TOP_MARGIN = 0.025;
+        double MEDIA_RIGHT_MARGIN = 0.025;
+        double MEDIA_BOTTOM_MARGIN = 0.025;
+        double MEDIA_LEFT_MARGIN = 0.025;
+    }
 
     /*
      * Making sure public utility methods remain static
@@ -67,6 +80,25 @@ public class Utils {
     public static int convertDpToPixel(Context ctx, int dp) {
         float density = ctx.getResources().getDisplayMetrics().density;
         return Math.round((float) dp * density);
+    }
+
+
+    /**
+     * Example for handling resizing content for overscan.  Typically you won't need to resize
+     * when using the Leanback support library.
+     */
+    public void overScan(Activity activity, VideoView videoView) {
+        DisplayMetrics metrics = new DisplayMetrics();
+        activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        int w = (int) (metrics.widthPixels * MediaDimensions.MEDIA_WIDTH);
+        int h = (int) (metrics.heightPixels * MediaDimensions.MEDIA_HEIGHT);
+        int marginLeft = (int) (metrics.widthPixels * MediaDimensions.MEDIA_LEFT_MARGIN);
+        int marginTop = (int) (metrics.heightPixels * MediaDimensions.MEDIA_TOP_MARGIN);
+        int marginRight = (int) (metrics.widthPixels * MediaDimensions.MEDIA_RIGHT_MARGIN);
+        int marginBottom = (int) (metrics.heightPixels * MediaDimensions.MEDIA_BOTTOM_MARGIN);
+        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(w, h);
+        lp.setMargins(marginLeft, marginTop, marginRight, marginBottom);
+        videoView.setLayoutParams(lp);
     }
 
 

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
@@ -54,7 +54,6 @@ import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.example.android.tvleanback.R;
-import com.example.android.tvleanback.Utils;
 import com.example.android.tvleanback.data.VideoProvider;
 import com.example.android.tvleanback.model.Movie;
 import com.example.android.tvleanback.presenter.CardPresenter;
@@ -100,7 +99,6 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
     private PlaybackControlsRow mPlaybackControlsRow;
     private ArrayList<Movie> mItems = new ArrayList<Movie>();
     private int mCurrentItem;
-    private long mDuration;
     private Handler mHandler;
     private Runnable mRunnable;
     private Movie mSelectedMovie;
@@ -117,8 +115,8 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
         Log.i(TAG, "onCreate");
         super.onCreate(savedInstanceState);
         
-        mItems = new ArrayList<Movie>();
-        mSelectedMovie = (Movie) getActivity()
+        mItems = new ArrayList<>();
+        mSelectedMovie = getActivity()
                 .getIntent().getParcelableExtra(MovieDetailsActivity.MOVIE);
 
         HashMap<String, List<Movie>> movies = VideoProvider.getMovieList();
@@ -240,11 +238,6 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
         }
     }
 
-    private int getDuration() {
-        mDuration = Utils.getDuration(mItems.get(mCurrentItem).getVideoUrl());
-        return (int) mDuration;
-    }
-
     private void addPlaybackControlsRow() {
         if (SHOW_DETAIL) {
             mPlaybackControlsRow = new PlaybackControlsRow(mSelectedMovie);
@@ -322,7 +315,6 @@ public class PlaybackOverlayFragment extends android.support.v17.leanback.app.Pl
             item.setTitle(title);
             item.setStudio(studio);
         }
-        mDuration = duration;
         mPlaybackControlsRow.setTotalTime((int) duration);
 
         if (SHOW_IMAGE) {


### PR DESCRIPTION
the PlaybackActivity has to keep track of the current playback position and maintain the position without relying on videoView.getCurrentPosition. This is required because this method returns zero when visible behind the launcher and the user can press play/pause.