### PR TITLE
Improve Performance of Movie Selection in PlaybackActivity

### DIFF
--- a/app/src/main/java/com/example/android/tvleanback/data/VideoProvider.java
+++ b/app/src/main/java/com/example/android/tvleanback/data/VideoProvider.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
@@ -53,12 +54,18 @@ public class VideoProvider {
     private static String TAG_TITLE = "title";
 
     private static HashMap<String, List<Movie>> sMovieList;
+    private static HashMap<String, Movie> sMovieListById;
+
     private static Context sContext;
     private static String sPrefixUrl;
 
     public static void setContext(Context context) {
         if (sContext == null)
             sContext = context;
+    }
+
+    public static Movie getMovieById(String mediaId) {
+        return sMovieListById.get(mediaId);
     }
 
     public static HashMap<String, List<Movie>> getMovieList() {
@@ -70,7 +77,8 @@ public class VideoProvider {
         if (null != sMovieList) {
             return sMovieList;
         }
-        sMovieList = new HashMap<String, List<Movie>>();
+        sMovieList = new HashMap<>();
+        sMovieListById = new HashMap<>();
 
         JSONObject jsonObj = new VideoProvider().parseUrl(url);
         JSONArray categories = jsonObj.getJSONArray(TAG_GOOGLE_VIDEOS);
@@ -104,9 +112,11 @@ public class VideoProvider {
                         cardImageUrl = getThumbPrefix(category_name, title,
                                 video.getString(TAG_CARD_THUMB));
                         studio = video.getString(TAG_STUDIO);
-                        categoryList.add(buildMovieInfo(category_name, title, description, studio,
-                                videoUrl, cardImageUrl,
-                                bgImageUrl));
+
+                        Movie movie = buildMovieInfo(category_name, title, description, studio,
+                                videoUrl, cardImageUrl, bgImageUrl);
+                        sMovieListById.put(movie.getId(), movie);
+                        categoryList.add(movie);
                     }
                     sMovieList.put(category_name, categoryList);
                 }

--- a/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/PlaybackActivity.java
@@ -276,7 +276,7 @@ public class PlaybackActivity extends Activity {
 
         @Override
         public void onPlayFromMediaId(String mediaId, Bundle extras) {
-            Movie movie = getMovieById(mediaId);
+            Movie movie = VideoProvider.getMovieById(mediaId);
             if (movie != null) {
                 setVideoPath(movie.getVideoUrl());
                 mPlaybackState = LeanbackPlaybackState.PAUSED;
@@ -316,17 +316,5 @@ public class PlaybackActivity extends Activity {
         mVideoView.setVideoPath(videoUrl);
         mStartTimeMillis = 0;
         mDuration = Utils.getDuration(videoUrl);
-    }
-
-    private Movie getMovieById(String mediaId) {
-        Collection<List<Movie>> movies = VideoProvider.getMovieList().values();
-        for (List<Movie> category :movies) {
-            for (Movie movie: category) {
-                if (movie.getId().equals(mediaId)) {
-                    return movie;
-                }
-            }
-        }
-        return null;
     }
 }


### PR DESCRIPTION
Building a index of all movie objects within the ```VideoProvider``` while ingesting the video content is more performant when going to look for the video requested to play in ```PlaybackActivity```. 