### PR TITLE
Fixing Fatal Error Reported by Lint

### DIFF
--- a/app/src/main/java/com/example/android/tvleanback/ui/GuidedStepActivity.java
+++ b/app/src/main/java/com/example/android/tvleanback/ui/GuidedStepActivity.java
@@ -153,16 +153,27 @@ public class GuidedStepActivity extends Activity {
         @Override
         public void onGuidedActionClicked(GuidedAction action) {
             FragmentManager fm = getFragmentManager();
-            GuidedStepFragment.add(fm, new ThirdStepFragment(getSelectedActionPosition()-1));
+            GuidedStepFragment.add(fm, createThirdStepFragment());
         }
 
+        private ThirdStepFragment createThirdStepFragment() {
+            ThirdStepFragment thirdStepFragment = new ThirdStepFragment();
+            Bundle argumentBundle = new Bundle();
+            argumentBundle.putInt("option", getSelectedActionPosition()-1);
+            thirdStepFragment.setArguments(argumentBundle);
+            return thirdStepFragment;
+        }
     }
 
     public static class ThirdStepFragment extends GuidedStepFragment {
-        private final int mOption;
+        private int mOption;
 
-        public ThirdStepFragment(int option) {
-            mOption = option;
+        public ThirdStepFragment() {
+        }
+
+        @Override
+        public void setArguments(Bundle args) {
+            mOption = args.getInt("option");
         }
 
         @Override


### PR DESCRIPTION
Below is the output from running lint on the project. I have push the fix to add back a default constructor in favor of using the ```setArguments()``` method of constructing a ```Fragment```.

````
:app:lintVitalRelease
/Users/tmack/dev/private/android-apps/androidtv-Leanback/app/src/main/java/com/example/android/tvleanback/ui/GuidedStepActivity.java:163: Error: This fragment should provide a default constructor (a public constructor with no arguments) (com.example.android.tvleanback.ui.GuidedStepActivity.ThirdStepFragment) [ValidFragment]
    public static class ThirdStepFragment extends GuidedStepFragment {
                        ~~~~~~~~~~~~~~~~~
/Users/tmack/dev/private/android-apps/androidtv-Leanback/app/src/main/java/com/example/android/tvleanback/ui/GuidedStepActivity.java:166: Error: Avoid non-default constructors in fragments: use a default constructor plus Fragment#setArguments(Bundle) instead [ValidFragment]
        public ThirdStepFragment(Bundle bundle) {
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "ValidFragment":
   From the Fragment documentation:
   Every fragment must have an empty constructor, so it can be instantiated
   when restoring its activity's state. It is strongly recommended that
   subclasses do not have other constructors with parameters, since these
   constructors will not be called when the fragment is re-instantiated;
   instead, arguments can be supplied by the caller with setArguments(Bundle)
   and later retrieved by the Fragment with getArguments().

   http://developer.android.com/reference/android/app/Fragment.html#Fragment()

2 errors, 0 warnings
:app:lintVitalRelease FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintVitalRelease'.
> Lint found fatal errors while assembling a release target.
````