### PR TITLE
Switch to jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
@@ -14,6 +14,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }


### PR DESCRIPTION
fix #63. switch to jcenter from mavenCentral for ExoPlayer.

https://github.com/google/ExoPlayer#via-jcenter