### PR TITLE
fix global search

### DIFF
--- a/app/src/main/java/com/example/android/tvleanback/data/VideoProvider.java
+++ b/app/src/main/java/com/example/android/tvleanback/data/VideoProvider.java
@@ -95,8 +95,8 @@ public class VideoProvider extends ContentProvider {
         matcher.addURI(authority, VideoContract.PATH_VIDEO + "/*", VIDEO_WITH_CATEGORY);
 
         // Search related URIs.
-        matcher.addURI(authority, SearchManager.SUGGEST_URI_PATH_QUERY, SEARCH_SUGGEST);
-        matcher.addURI(authority, SearchManager.SUGGEST_URI_PATH_QUERY + "/*", SEARCH_SUGGEST);
+        matcher.addURI(authority, "search/" + SearchManager.SUGGEST_URI_PATH_QUERY, SEARCH_SUGGEST);
+        matcher.addURI(authority, "search/" + SearchManager.SUGGEST_URI_PATH_QUERY + "/*", SEARCH_SUGGEST);
         return matcher;
     }
 

--- a/app/src/main/res/xml/searchable.xml
+++ b/app/src/main/res/xml/searchable.xml
@@ -27,9 +27,10 @@
     android:label="@string/search_label"
     android:icon="@drawable/lb_ic_in_app_search"
     android:searchSettingsDescription="@string/settings_description"
-    android:searchSuggestAuthority="com.example.android.leanback"
+    android:searchSuggestAuthority="com.example.android.tvleanback"
     android:searchSuggestIntentAction="android.intent.action.VIEW"
     android:searchSuggestIntentData="content://com.example.android.tvleanback/video"
     android:queryAfterZeroResults="true"
     android:searchSuggestPath="search"
+    android:searchSuggestSelection=" ?"
     android:searchSuggestThreshold="0" />


### PR DESCRIPTION
This change makes global search works for Android 7.x and below.

(I have no idea why Android 8.x does not works after applying this changes, so I've created an [issue](https://issuetracker.google.com/u/1/issues/72407281) for it)